### PR TITLE
Add exclusion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,17 @@ source path/to/print-alias.plugin.zsh
 Configuration
 -------------
 
-You can change the line prefix as well as the format of expanded aliases and non-aliases:
+You can change the line prefix as well as the format of expanded aliases and non-aliases.
+You can exclude some specific aliases to be displayed.
+You may as well prevent any command which has been redefined by an alias to be displayed (aliases such as `alias grep='grep --colour'` or `alias ls='ls -aF'`)
 
 ```zsh
 export PRINT_ALIAS_PREFIX='  ╰─> '
 export PRINT_ALIAS_FORMAT=$'\e[1m'
 export PRINT_NON_ALIAS_FORMAT=$'\e[0m'
+
+export PRINT_ALIAS_IGNORE_REDEFINED_COMMANDS=true
+export PRINT_ALIAS_IGNORE_ALIASES=(my_alias my_other_alias)
 
 zplug "brymck/print-alias"
 ```

--- a/print-alias.plugin.zsh
+++ b/print-alias.plugin.zsh
@@ -4,14 +4,26 @@ _print-alias () {
     local -r ALIAS_FORMAT=${PRINT_ALIAS_FORMAT:-$'\e[36m'}
     local -r NON_ALIAS_FORMAT=${PRINT_NON_ALIAS_FORMAT:-$'\e[2m'}
     local -r RESET_COLORS=$'\e[0m'
+    local -r IGNORE_ALIASES=(${PRINT_ALIAS_IGNORE_ALIASES:-})
+    local -r IGNORE_REDEFINED_COMMANDS=${PRINT_ALIAS_IGNORE_REDEFINED_COMMANDS:-'false'}
 
     local -a words
     words=( ${(z)BUFFER} )
 
     local -r first_word=${words[1]}
+    if [[ ${IGNORE_ALIASES[(ie)$first_word]} -le ${#IGNORE_ALIASES} ]]; then
+        return
+    fi
+
     if [[ "$(whence -w $first_word 2>/dev/null)" == "${first_word}: alias" ]]; then
         shift words
-        echo -nE $'\n'"${PREFIX}${ALIAS_FORMAT}$(whence $first_word)${RESET_COLORS}"
+        local -r aliased_command=($(whence $first_word))
+        if [[ $IGNORE_REDEFINED_COMMANDS == 'true' ]]; then
+            if [[ $first_word == ${aliased_command[1]} ]]; then
+                return
+            fi
+        fi
+        echo -nE $'\n'"${PREFIX}${ALIAS_FORMAT}${aliased_command}${RESET_COLORS}"
         for word in $words; do
             echo -nE " ${NON_ALIAS_FORMAT}${word}${RESET_COLORS}"
         done


### PR DESCRIPTION
You can exclude some specific aliases to be displayed.
You may as well prevent any command which has been redefined by an alias to be displayed (aliases such as `alias grep='grep --colour'` or `alias ls='ls -aF'`)

```zsh
export PRINT_ALIAS_IGNORE_REDEFINED_COMMANDS=true
export PRINT_ALIAS_IGNORE_ALIASES=(my_alias my_other_alias)
```
